### PR TITLE
fix(GitHub Actions) : hosting重複削除 #24

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -11,16 +11,6 @@
   },
   "hosting": [
     {
-      "public": "dist/fil-portal",
-      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-      "rewrites": [
-        {
-          "source": "**",
-          "destination": "/index.html"
-        }
-      ]
-    },
-    {
       "target": "fil-portal",
       "public": "dist/fil-portal",
       "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],


### PR DESCRIPTION
fix #24 

## Detail

 - GitHub Actionsデプロイにおいて下記のエラーがでました。何度も申し訳ございません。。。

![image](https://user-images.githubusercontent.com/45907309/81780721-f7b51f80-9531-11ea-9612-b9a0184145cd.png)

 - 確認したところfirebase.jsonのhostingで重複がありましたので削除いたしました。

何度も申し訳ございませんがご確認お願いいたします。