### PR TITLE
feat(detail) : 記事詳細ページ追加 #28

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,6 +7,11 @@ const routes: Routes = [
     pathMatch: 'full',
     loadChildren: () => import('./home/home.module').then((m) => m.HomeModule),
   },
+  {
+    path: 'detail/:id',
+    loadChildren: () =>
+      import('./detail/detail.module').then((m) => m.DetailModule),
+  },
 ];
 
 @NgModule({

--- a/src/app/article/article.component.html
+++ b/src/app/article/article.component.html
@@ -1,8 +1,9 @@
 <div class="grid">
-  <mat-card *ngFor="let item of items" [routerLink]="['/detail, item.id']">
+  <mat-card *ngFor="let item of items">
     <img src="../../assets/Slowool15_Nm2_58_1888.jpg" alt="" />
     <p>{{ item.supplier }}</p>
     <h3>{{ item.title }}</h3>
     <p>{{ item.season }}</p>
+    <button [routerLink]="['/detail', item.id]">詳細画面へ</button>
   </mat-card>
 </div>

--- a/src/app/article/article.component.ts
+++ b/src/app/article/article.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ArticleService } from '../services/article.service';
 
 @Component({
   selector: 'app-article',
@@ -6,34 +7,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./article.component.scss'],
 })
 export class ArticleComponent implements OnInit {
-  items = [
-    {
-      id: 'aaa',
-      supplier: 'Botto giuseppe',
-      title: 'ALBA 2/30, 2/48',
-      season: '20-21aw',
-    },
-    {
-      id: 'bbb',
-      supplier: 'Botto giuseppe',
-      title: 'ALBA 2/30, 2/48',
-      season: '20-21aw',
-    },
-    {
-      id: 'ccc',
-      supplier: 'Botto giuseppe',
-      title: 'ALBA 2/30, 2/48',
-      season: '20-21aw',
-    },
-    {
-      id: 'ddd',
-      supplier: 'Botto giuseppe',
-      title: 'ALBA 2/30, 2/48',
-      season: '20-21aw',
-    },
-  ];
+  items = this.articleService.items;
 
-  constructor() {}
+  constructor(private articleService: ArticleService) {}
 
   ngOnInit(): void {}
 }

--- a/src/app/detail/detail-routing.module.ts
+++ b/src/app/detail/detail-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { DetailComponent } from './detail.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: DetailComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class DetailRoutingModule {}

--- a/src/app/detail/detail.component.html
+++ b/src/app/detail/detail.component.html
@@ -1,0 +1,10 @@
+<div *ngIf="article; else blank">
+  <img src="../../assets/Slowool15_Nm2_58_1888.jpg" alt="" />
+  <p>{{ article.supplier }}</p>
+  <h3>{{ article.title }}</h3>
+  <p>{{ article.season }}</p>
+</div>
+
+<ng-template #blank>
+  <p>Not Found</p>
+</ng-template>

--- a/src/app/detail/detail.component.spec.ts
+++ b/src/app/detail/detail.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DetailComponent } from './detail.component';
+
+describe('DetailComponent', () => {
+  let component: DetailComponent;
+  let fixture: ComponentFixture<DetailComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [DetailComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/detail/detail.component.ts
+++ b/src/app/detail/detail.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { ArticleService } from '../services/article.service';
+
+@Component({
+  selector: 'app-detail',
+  templateUrl: './detail.component.html',
+  styleUrls: ['./detail.component.scss'],
+})
+export class DetailComponent implements OnInit {
+  article;
+
+  constructor(
+    private route: ActivatedRoute,
+    private articleService: ArticleService
+  ) {}
+
+  ngOnInit(): void {
+    this.route.paramMap.subscribe((map) => {
+      const id = map.get('id');
+      this.article = this.articleService.getArticle(id);
+      console.log(this.article);
+    });
+  }
+}

--- a/src/app/detail/detail.module.ts
+++ b/src/app/detail/detail.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { DetailRoutingModule } from './detail-routing.module';
+import { DetailComponent } from './detail.component';
+
+@NgModule({
+  declarations: [DetailComponent],
+  imports: [CommonModule, DetailRoutingModule],
+})
+export class DetailModule {}

--- a/src/app/services/article.service.spec.ts
+++ b/src/app/services/article.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ArticleService } from './article.service';
+
+describe('ArticleService', () => {
+  let service: ArticleService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ArticleService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ArticleService {
+  items = [
+    {
+      id: 'aaa',
+      supplier: 'Botto giuseppe',
+      title: 'ALBA 2/30, 2/48',
+      season: '20-21aw',
+    },
+    {
+      id: 'bbb',
+      supplier: 'Botto giuseppe',
+      title: 'ALBA 2/30, 2/48',
+      season: '20-21aw',
+    },
+    {
+      id: 'ccc',
+      supplier: 'Botto giuseppe',
+      title: 'ALBA 2/30, 2/48',
+      season: '20-21aw',
+    },
+    {
+      id: 'ddd',
+      supplier: 'Botto giuseppe',
+      title: 'ALBA 2/30, 2/48',
+      season: '20-21aw',
+    },
+  ];
+
+  constructor() {}
+
+  createArticle() {}
+  updateArticle() {}
+  deleteArticle() {}
+  getArticle(id: string) {
+    return this.items.find((item) => item.id === id);
+  }
+}


### PR DESCRIPTION
fix #28 

## Detail
 - 記事一覧画面の詳細画面へをクリックすると、記事の詳細ページが表示されるようにしました。


## Image
![image](https://user-images.githubusercontent.com/45907309/82136584-59cf9680-984a-11ea-9071-ac9494c291eb.png)

ご確認お願いいたします。
