### PR TITLE
feat(create) : 記事作成ページ追加 #29

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -12,6 +12,11 @@ const routes: Routes = [
     loadChildren: () =>
       import('./detail/detail.module').then((m) => m.DetailModule),
   },
+  {
+    path: 'create',
+    loadChildren: () =>
+      import('./create/create.module').then((m) => m.CreateModule),
+  },
 ];
 
 @NgModule({

--- a/src/app/create/create-routing.module.ts
+++ b/src/app/create/create-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { CreateComponent } from './create/create.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: CreateComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class CreateRoutingModule {}

--- a/src/app/create/create.module.ts
+++ b/src/app/create/create.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { CreateRoutingModule } from './create-routing.module';
+import { CreateComponent } from './create/create.component';
+import { SharedModule } from '../shared/shared.module';
+
+@NgModule({
+  declarations: [CreateComponent],
+  imports: [CommonModule, CreateRoutingModule, SharedModule],
+})
+export class CreateModule {}

--- a/src/app/create/create/create.component.html
+++ b/src/app/create/create/create.component.html
@@ -1,0 +1,143 @@
+<h1>Add New Article</h1>
+
+<div class="container">
+  <form [formGroup]="form" (ngSubmit)="submit()">
+    <mat-form-field>
+      <mat-label>Supplier</mat-label>
+      <mat-select formControlName="supplier" disableRipple>
+        <mat-option value="Botto Giuseppe">Botto Giuseppe</mat-option>
+        <mat-option value="Linea Piu">Linea Piu</mat-option>
+        <mat-option value="ZhongDing">ZhongDing</mat-option>
+        <mat-option value="Ferrari">Ferrari</mat-option>
+        <mat-option value="ZhongDing">ZhongDing</mat-option>
+      </mat-select>
+      <mat-error *ngIf="supplierControl.hasError('required')"
+        >必須入力です</mat-error
+      >
+    </mat-form-field>
+
+    <mat-form-field class="name-input" appearance="outline">
+      <mat-label>yarn name</mat-label>
+      <input
+        formControlName="name"
+        placeholder="yarn name"
+        type="text"
+        matInput
+        autocomplete="off"
+        required
+      />
+      <mat-error *ngIf="nameControl.hasError('required')"
+        >必須入力です</mat-error
+      >
+      <mat-error *ngIf="nameControl.hasError('maxlength')"
+        >長過ぎます</mat-error
+      >
+    </mat-form-field>
+
+    <mat-form-field class="name-input" appearance="outline">
+      <mat-label>Composition</mat-label>
+      <input
+        formControlName="composition"
+        placeholder="composition"
+        type="text"
+        matInput
+        autocomplete="off"
+        required
+      />
+      <mat-error *ngIf="compositionControl.hasError('required')"
+        >必須入力です</mat-error
+      >
+      <mat-error *ngIf="compositionControl.hasError('maxlength')"
+        >長過ぎます</mat-error
+      >
+    </mat-form-field>
+
+    <p>Season</p>
+    <mat-radio-group class="radio-group" formControlName="season">
+      <mat-radio-button class="radio-group__item" value="21SS"
+        >21SS</mat-radio-button
+      >
+      <mat-radio-button class="radio-group__item" value="20-21AW"
+        >20-21AW</mat-radio-button
+      >
+    </mat-radio-group>
+
+    <p>Type</p>
+    <mat-radio-group class="radio-group" formControlName="type">
+      <mat-radio-button class="radio-group__item" value="Worsted"
+        >Worsted</mat-radio-button
+      >
+      <mat-radio-button class="radio-group__item" value="Woollen"
+        >Woollen</mat-radio-button
+      >
+      <mat-radio-button class="radio-group__item" value="semi-Worsted"
+        >semi-Worsted</mat-radio-button
+      >
+      <mat-radio-button class="radio-group__item" value="Fancy"
+        >Fancy</mat-radio-button
+      >
+    </mat-radio-group>
+
+    <p>gauges</p>
+    <div class="checkbox-group" formGroupName="gauges">
+      <mat-checkbox
+        class="checkbox-group__item"
+        type="checkbox"
+        formControlName="3-5gg"
+        >3-5gg</mat-checkbox
+      >
+      <mat-checkbox
+        class="checkbox-group__item"
+        type="checkbox"
+        formControlName="5-7gg"
+        >5-7gg</mat-checkbox
+      >
+      <mat-checkbox
+        class="checkbox-group__item"
+        type="checkbox"
+        formControlName="12-14gg"
+        >12-14gg</mat-checkbox
+      >
+      <mat-checkbox
+        class="checkbox-group__item"
+        type="checkbox"
+        formControlName="16-18gg"
+        >16-18gg</mat-checkbox
+      >
+    </div>
+
+    <p>others</p>
+    <div class="checkbox-group" formGroupName="otherFeatures">
+      <mat-checkbox
+        class="checkbox-group__item"
+        type="checkbox"
+        formControlName="newss"
+        >New for SS</mat-checkbox
+      >
+      <mat-checkbox
+        class="checkbox-group__item"
+        type="checkbox"
+        formControlName="newaw"
+        >New for AW</mat-checkbox
+      >
+      <mat-checkbox
+        class="checkbox-group__item"
+        type="checkbox"
+        formControlName="stockService"
+        >Stock Service</mat-checkbox
+      >
+      <mat-checkbox
+        class="checkbox-group__item"
+        type="checkbox"
+        formControlName="sustainability"
+        >Sustainability</mat-checkbox
+      >
+    </div>
+
+    <div class="form-footer">
+      <button [disabled]="form.invalid" mat-raised-button color="primary">
+        Add
+      </button>
+    </div>
+  </form>
+</div>

--- a/src/app/create/create/create.component.scss
+++ b/src/app/create/create/create.component.scss
@@ -1,0 +1,34 @@
+h1 {
+  font-size: 24px;
+  text-align: center;
+  margin: 40px 0;
+}
+
+.name-input {
+  width: 100%;
+}
+
+.radio-group {
+  margin-bottom: 32px;
+  display: block;
+  &__item {
+    margin-right: 24px;
+  }
+}
+
+.checkbox-group {
+  margin-bottom: 32px;
+  display: block;
+  &__item {
+    margin-right: 24px;
+  }
+}
+
+.form-footer {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.label {
+  font-size: 14px;
+}

--- a/src/app/create/create/create.component.spec.ts
+++ b/src/app/create/create/create.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateComponent } from './create.component';
+
+describe('CreateComponent', () => {
+  let component: CreateComponent;
+  let fixture: ComponentFixture<CreateComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [CreateComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CreateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/create/create/create.component.ts
+++ b/src/app/create/create/create.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, Validators, FormControl } from '@angular/forms';
+
+@Component({
+  selector: 'app-create',
+  templateUrl: './create.component.html',
+  styleUrls: ['./create.component.scss'],
+})
+export class CreateComponent implements OnInit {
+  form = this.fb.group({
+    supplier: ['', [Validators.required]],
+    name: ['', [Validators.required, Validators.maxLength(40)]],
+    composition: ['', [Validators.required, Validators.maxLength(40)]],
+    season: ['', [Validators.required, Validators.pattern(/21SS|20-21AW/)]],
+    type: ['', [Validators.required]],
+    gauges: this.fb.group({
+      '3-5gg': [false],
+      '5-7gg': [false],
+      '12-14gg': [false],
+      '16-18gg': [false],
+    }),
+    otherFeatures: this.fb.group({
+      newss: [false],
+      newaw: [false],
+      stockService: [false],
+      sustainability: [false],
+    }),
+  });
+
+  get supplierControl() {
+    return this.form.get('supplier') as FormControl;
+  }
+  get nameControl() {
+    return this.form.get('name') as FormControl;
+  }
+  get compositionControl() {
+    return this.form.get('composition') as FormControl;
+  }
+
+  constructor(private fb: FormBuilder) {}
+
+  ngOnInit(): void {}
+
+  submit() {
+    console.log(this.form.value);
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -6,6 +6,11 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatCardModule } from '@angular/material/card';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
 
 @NgModule({
   declarations: [],
@@ -17,6 +22,12 @@ import { MatCardModule } from '@angular/material/card';
     MatButtonModule,
     MatMenuModule,
     MatCardModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatCheckboxModule,
+    MatRadioModule,
+    MatSelectModule,
   ],
 })
 export class SharedModule {}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -12,3 +12,9 @@ body {
 img {
   max-width: 100%;
 }
+
+.container {
+  max-width: 1200px;
+  padding: 0 24px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
fix #29 

## Detail
 - create module, componentを作成し、新規記事の作成ページを追加しました。

 - 現状は項目を入力するとconsole.logに出力される状態になっています。(※図1)

 - select, inputの項目については必須入力、入力されていない場合エラーメッセージが出るようにしました。radioの項目についても必須入力にしております。checkboxは必須にしておりません。(※図２)

## Image
[図1]
![image](https://user-images.githubusercontent.com/45907309/82295338-96d28f00-99ea-11ea-8f96-09fb421748c5.png)

[図2]
![image](https://user-images.githubusercontent.com/45907309/82295595-f2048180-99ea-11ea-9083-2098e108c9b1.png)

ご確認お願いいたします。