### PR TITLE
feat(article) : 記事投稿・表示機能作成 #38

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,7 +2,8 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      allow read, write: if request.auth != null;
+      allow read: if true;
+      allow write: if request.auth != null;
     }
   }
 }

--- a/src/app/article/article.component.html
+++ b/src/app/article/article.component.html
@@ -1,9 +1,14 @@
 <div class="grid">
-  <mat-card *ngFor="let item of items">
-    <img src="../../assets/Slowool15_Nm2_58_1888.jpg" alt="" />
-    <p>{{ item.supplier }}</p>
-    <h3>{{ item.title }}</h3>
-    <p>{{ item.season }}</p>
-    <button [routerLink]="['/detail', item.id]">詳細画面へ</button>
+  <mat-card *ngFor="let article of articles$ | async">
+    <p>supplier : {{ article.supplier }}</p>
+    <p>name : {{ article.name }}</p>
+    <p>composition : {{ article.composition }}</p>
+    <button
+      mat-raised-button
+      color="primary"
+      [routerLink]="['/detail', article.id]"
+    >
+      詳細画面へ
+    </button>
   </mat-card>
 </div>

--- a/src/app/article/article.component.ts
+++ b/src/app/article/article.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ArticleService } from '../services/article.service';
+import { Article } from '../interfaces/article';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-article',
@@ -7,7 +9,7 @@ import { ArticleService } from '../services/article.service';
   styleUrls: ['./article.component.scss'],
 })
 export class ArticleComponent implements OnInit {
-  items = this.articleService.items;
+  articles$: Observable<Article[]> = this.articleService.getArticles();
 
   constructor(private articleService: ArticleService) {}
 

--- a/src/app/create/create/create.component.ts
+++ b/src/app/create/create/create.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, Validators, FormControl } from '@angular/forms';
+import { ArticleService } from 'src/app/services/article.service';
+import { AuthService } from 'src/app/services/auth.service';
 
 @Component({
   selector: 'app-create',
@@ -37,11 +39,36 @@ export class CreateComponent implements OnInit {
     return this.form.get('composition') as FormControl;
   }
 
-  constructor(private fb: FormBuilder) {}
+  constructor(
+    private fb: FormBuilder,
+    private articleService: ArticleService,
+    private authService: AuthService
+  ) {}
 
   ngOnInit(): void {}
 
+  private dataToArray(data: object): string[] {
+    if (data) {
+      return Object.entries(data)
+        .filter(([key, value]) => value)
+        .map(([key, value]) => key);
+    } else {
+      return [];
+    }
+  }
+
   submit() {
+    const formData = this.form.value;
     console.log(this.form.value);
+    this.articleService.createArticle({
+      supplier: formData.supplier,
+      name: formData.name,
+      composition: formData.composition,
+      season: formData.season,
+      type: formData.type,
+      gauges: this.dataToArray(formData.gauges),
+      otherFeatures: this.dataToArray(formData.otherFeatures),
+      userId: this.authService.uid,
+    });
   }
 }

--- a/src/app/detail/detail.component.html
+++ b/src/app/detail/detail.component.html
@@ -1,10 +1,12 @@
-<div *ngIf="article; else blank">
-  <img src="../../assets/Slowool15_Nm2_58_1888.jpg" alt="" />
-  <p>{{ article.supplier }}</p>
-  <h3>{{ article.title }}</h3>
-  <p>{{ article.season }}</p>
+<div class="container">
+  <div *ngIf="article$ | async as article">
+    <p>supplier : {{ article.supplier }}</p>
+    <p>name : {{ article.name }}</p>
+    <p>composition : {{ article.composition }}</p>
+    <p>season : {{ article.season }}</p>
+    <p>type : {{ article.type }}</p>
+    <p>gauges : {{ article.gauges }}</p>
+    <p>otherFeatures : {{ article.otherFeatures }}</p>
+    <p>userId : {{ article.userId }}</p>
+  </div>
 </div>
-
-<ng-template #blank>
-  <p>Not Found</p>
-</ng-template>

--- a/src/app/detail/detail.component.ts
+++ b/src/app/detail/detail.component.ts
@@ -1,6 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ArticleService } from '../services/article.service';
+import { Article } from '../interfaces/article';
+import { Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-detail',
@@ -8,7 +11,7 @@ import { ArticleService } from '../services/article.service';
   styleUrls: ['./detail.component.scss'],
 })
 export class DetailComponent implements OnInit {
-  article;
+  article$: Observable<Article>;
 
   constructor(
     private route: ActivatedRoute,
@@ -16,10 +19,11 @@ export class DetailComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.route.paramMap.subscribe((map) => {
-      const id = map.get('id');
-      this.article = this.articleService.getArticle(id);
-      console.log(this.article);
-    });
+    this.article$ = this.route.paramMap.pipe(
+      switchMap((prams) => {
+        const id = prams.get('id');
+        return this.articleService.getArticle(id);
+      })
+    );
   }
 }

--- a/src/app/interfaces/article.ts
+++ b/src/app/interfaces/article.ts
@@ -1,0 +1,11 @@
+export interface Article {
+  supplier: string;
+  name: string;
+  composition: string;
+  season: string;
+  type: string;
+  gauges: string[];
+  otherFeatures: string[];
+  userId: string;
+  id: string;
+}

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -1,42 +1,33 @@
 import { Injectable } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { Article } from '../interfaces/article';
+import { firestore } from 'firebase';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ArticleService {
-  items = [
-    {
-      id: 'aaa',
-      supplier: 'Botto giuseppe',
-      title: 'ALBA 2/30, 2/48',
-      season: '20-21aw',
-    },
-    {
-      id: 'bbb',
-      supplier: 'Botto giuseppe',
-      title: 'ALBA 2/30, 2/48',
-      season: '20-21aw',
-    },
-    {
-      id: 'ccc',
-      supplier: 'Botto giuseppe',
-      title: 'ALBA 2/30, 2/48',
-      season: '20-21aw',
-    },
-    {
-      id: 'ddd',
-      supplier: 'Botto giuseppe',
-      title: 'ALBA 2/30, 2/48',
-      season: '20-21aw',
-    },
-  ];
+  constructor(private db: AngularFirestore) {}
 
-  constructor() {}
+  createArticle(article: Omit<Article, 'id' | 'createdAt'>): Promise<void> {
+    const id = this.db.createId();
+    return this.db.doc(`articles/${id}`).set({
+      id,
+      ...article,
+      craetedAt: firestore.Timestamp.now(), // firestore形式のタイムスタンプを追加
+    });
+  }
 
-  createArticle() {}
   updateArticle() {}
+
   deleteArticle() {}
+
   getArticle(id: string) {
-    return this.items.find((item) => item.id === id);
+    return this.db.doc<Article>(`articles/${id}`).valueChanges();
+  }
+
+  getArticles(): Observable<Article[]> {
+    return this.db.collection<Article>(`articles`).valueChanges();
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -5,13 +5,10 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { switchMap } from 'rxjs/operators';
 import { User } from '../interfaces/user';
 
-
-
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class AuthService {
-
   user$: Observable<User> = this.afAuth.authState.pipe(
     switchMap((afUser) => {
       if (afUser) {
@@ -21,15 +18,15 @@ export class AuthService {
       }
     })
   );
+  uid: string;
 
-  constructor(
-    public afAuth: AngularFireAuth,
-    private db: AngularFirestore
-  ) {
-    this.user$.subscribe(user => console.log(user));
+  constructor(public afAuth: AngularFireAuth, private db: AngularFirestore) {
+    this.user$.subscribe((user) => {
+      this.uid = user && user.userId;
+    });
   }
 
-  createUser(params: { email: string; password: string}) {
+  createUser(params: { email: string; password: string }) {
     this.afAuth
       .createUserWithEmailAndPassword(params.email, params.password)
       .then((result) => {


### PR DESCRIPTION
fix #38 

MTGではありがとうございました。

## Detail
 - 新規記事を投稿 → firestoreにデータを格納 → firestoreからデータを取得・記事一覧を表示 →記事のボタンクリックで詳細ページ表示されるように実装いたしました。

 - MTGで教えていただきましたチェックボックスでのデータの表示についても無事詳細ページで表示されました。

## Image
[![Image from Gyazo](https://i.gyazo.com/5d19307bf97489ebb60de674c047f055.gif)](https://gyazo.com/5d19307bf97489ebb60de674c047f055)