### PR TITLE
feat(cart) : カート画面作成 #71

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -24,6 +24,10 @@ const routes: Routes = [
       import('./register/register.module').then((m) => m.RegisterModule),
   },
   {
+    path: 'cart',
+    loadChildren: () => import('./cart/cart.module').then((m) => m.CartModule),
+  },
+  {
     path: '**',
     component: NotFoundComponent,
   },

--- a/src/app/cart/cart-routing.module.ts
+++ b/src/app/cart/cart-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { CartComponent } from './cart/cart.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: CartComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class CartRoutingModule {}

--- a/src/app/cart/cart.module.ts
+++ b/src/app/cart/cart.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { CartRoutingModule } from './cart-routing.module';
+import { CartComponent } from './cart/cart.component';
+
+@NgModule({
+  declarations: [CartComponent],
+  imports: [CommonModule, CartRoutingModule],
+})
+export class CartModule {}

--- a/src/app/cart/cart/cart.component.html
+++ b/src/app/cart/cart/cart.component.html
@@ -1,0 +1,1 @@
+<p>cart works!</p>

--- a/src/app/cart/cart/cart.component.spec.ts
+++ b/src/app/cart/cart/cart.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CartComponent } from './cart.component';
+
+describe('CartComponent', () => {
+  let component: CartComponent;
+  let fixture: ComponentFixture<CartComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [CartComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CartComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/cart/cart/cart.component.ts
+++ b/src/app/cart/cart/cart.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-cart',
+  templateUrl: './cart.component.html',
+  styleUrls: ['./cart.component.scss'],
+})
+export class CartComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/detail/detail.component.html
+++ b/src/app/detail/detail.component.html
@@ -16,5 +16,9 @@
       <mat-icon>edit</mat-icon>
       <span>編集</span>
     </button>
+    <button mat-button>
+      <mat-icon>shopping_cart</mat-icon>
+      <span>カートに追加する</span>
+    </button>
   </div>
 </div>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -24,7 +24,7 @@
 
   <span class="spacer"></span>
 
-  <button mat-icon-button>
+  <button mat-icon-button [routerLink]="['cart']">
     <mat-icon>shopping_cart</mat-icon>
   </button>
 


### PR DESCRIPTION
fix #71 

質問させていただきました"[カート機能の実装方法が知りたいです](https://github.com/camp-team/camp-team/issues/320)"の内容を実装進行しております。

## 今回実装した内容
- [x] cartモジュール・コンポーネント作成
- [x] headerのカートアイコンからcartコンポーネントに遷移するよう設定
- [x] 記事の詳細画面(detail)に「カートに追加」ボタンを作成

上記を実装いたしました。レビューよろしくおねがいします。

## 今後実装予定の内容
- [ ] 記事の詳細画面に設置した「カートに追加」のボタンをクリックすると、サブコレクション cart_itemsに記事のidが入ったドキュメントが作成される
- [ ] カート画面でobservableにてuserとarticle(記事)の情報を取得、pipeでサブコレクションcart_itemsのドキュメントに追加されているidと一致する記事のみ表示するよう加工する。 
