### PR TITLE
feat(cart) : カート追加機能実装 #80

### DIFF
--- a/src/app/detail/detail.component.html
+++ b/src/app/detail/detail.component.html
@@ -16,7 +16,7 @@
       <mat-icon>edit</mat-icon>
       <span>編集</span>
     </button>
-    <button mat-button>
+    <button mat-button (click)="addCart(article.articleId)">
       <mat-icon>shopping_cart</mat-icon>
       <span>カートに追加する</span>
     </button>

--- a/src/app/detail/detail.component.ts
+++ b/src/app/detail/detail.component.ts
@@ -4,6 +4,9 @@ import { ArticleService } from '../services/article.service';
 import { Article } from '../interfaces/article';
 import { Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
+import { CartService } from '../services/cart.service';
+import { AuthService } from '../services/auth.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-detail',
@@ -15,7 +18,10 @@ export class DetailComponent implements OnInit {
 
   constructor(
     private route: ActivatedRoute,
-    private articleService: ArticleService
+    private articleService: ArticleService,
+    private cartService: CartService,
+    private authService: AuthService,
+    private snackBar: MatSnackBar
   ) {}
 
   ngOnInit(): void {
@@ -25,5 +31,13 @@ export class DetailComponent implements OnInit {
         return this.articleService.getArticle(id);
       })
     );
+  }
+
+  addCart(articleId: string) {
+    return this.cartService
+      .addCart(this.authService.uid, articleId)
+      .then(() => {
+        this.snackBar.open('カートに追加しました', null);
+      });
   }
 }

--- a/src/app/services/cart.service.spec.ts
+++ b/src/app/services/cart.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CartService } from './cart.service';
+
+describe('CartService', () => {
+  let service: CartService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CartService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/firestore';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CartService {
+  constructor(private db: AngularFirestore) {}
+
+  addCart(userId: string, articleId: string): Promise<void> {
+    return this.db
+      .doc(`users/${userId}/cart_items/${articleId}`)
+      .set({ articleId });
+  }
+}


### PR DESCRIPTION
fix #80 

## 今回実装した内容
- [x] 記事の詳細画面に設置した「カートに追加」のボタンをクリックすると、サブコレクション cart_itemsに記事のidが入ったドキュメントが作成される

上記を実装いたしました。レビューよろしくおねがいします。

## Image
[![Image from Gyazo](https://i.gyazo.com/11ff7190282ab35659eb074da065fc72.gif)](https://gyazo.com/11ff7190282ab35659eb074da065fc72)

## 今後実装予定の内容
- [ ] カート画面でobservableにてuserとarticle(記事)の情報を取得、pipeでサブコレクションcart_itemsのドキュメントに追加されているidと一致する記事のみ表示するよう加工する。 
