### PR TITLE
feat(cart): カート一覧画面作成 #82

### DIFF
--- a/src/app/cart/cart.module.ts
+++ b/src/app/cart/cart.module.ts
@@ -3,9 +3,10 @@ import { CommonModule } from '@angular/common';
 
 import { CartRoutingModule } from './cart-routing.module';
 import { CartComponent } from './cart/cart.component';
+import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
   declarations: [CartComponent],
-  imports: [CommonModule, CartRoutingModule],
+  imports: [CommonModule, CartRoutingModule, SharedModule],
 })
 export class CartModule {}

--- a/src/app/cart/cart/cart.component.html
+++ b/src/app/cart/cart/cart.component.html
@@ -1,1 +1,13 @@
-<p>cart works!</p>
+<div class="grid">
+  <mat-card *ngFor="let user of users$ | async">
+    <p>追加した記事ID : {{ user.articleId }}</p>
+    <button
+      mat-button
+      mat-raised-button
+      color="primary"
+      (click)="deleteCartItem(this.user.articleId)"
+    >
+      Delete
+    </button>
+  </mat-card>
+</div>

--- a/src/app/cart/cart/cart.component.ts
+++ b/src/app/cart/cart/cart.component.ts
@@ -1,4 +1,10 @@
 import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ArticleService } from 'src/app/services/article.service';
+import { User } from '../../interfaces/user';
+import { CartService } from 'src/app/services/cart.service';
+import { AuthService } from 'src/app/services/auth.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-cart',
@@ -6,7 +12,23 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./cart.component.scss'],
 })
 export class CartComponent implements OnInit {
-  constructor() {}
+  users$: Observable<User[]> = this.cartService.getCartItems(
+    this.authService.uid
+  );
+
+  constructor(
+    private cartService: CartService,
+    private authService: AuthService,
+    private snackBar: MatSnackBar
+  ) {}
 
   ngOnInit(): void {}
+
+  deleteCartItem(articleId: string) {
+    return this.cartService
+      .deleteCartItem(this.authService.uid, articleId)
+      .then(() => {
+        this.snackBar.open('カートから削除しました', null);
+      });
+  }
 }

--- a/src/app/interfaces/user.ts
+++ b/src/app/interfaces/user.ts
@@ -2,4 +2,5 @@ export interface User {
   email: string;
   createdAt: Date;
   userId: string;
+  articleId: string;
 }

--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
+import { Observable, combineLatest } from 'rxjs';
+import { User } from '../interfaces/user';
 
 @Injectable({
   providedIn: 'root',
@@ -11,5 +13,15 @@ export class CartService {
     return this.db
       .doc(`users/${userId}/cart_items/${articleId}`)
       .set({ articleId });
+  }
+
+  getCartItems(userId: string): Observable<User[]> {
+    return this.db
+      .collection<User>(`users/${userId}/cart_items`)
+      .valueChanges();
+  }
+
+  deleteCartItem(userId: string, articleId: string): Promise<void> {
+    return this.db.doc(`users/${userId}/cart_items/${articleId}`).delete();
   }
 }


### PR DESCRIPTION
fix #82 

## 今回実装した内容
- [x] カード画面において、サブコレクションcart_itemsに入っているドキュメント(articleId)の一覧が表示される。

- [x] カード画面において、「Delete」ボタンをクリックするとサブコレクションcart_itemsに入っているドキュメントが削除される。

上記を実装いたしました。レビューよろしくおねがいします。

## Image
[![Image from Gyazo](https://i.gyazo.com/dea35c78090dabcc7a206074f2e3cf66.gif)](https://gyazo.com/dea35c78090dabcc7a206074f2e3cf66)

## 今後実装予定の内容
- [ ] カート画面でpipeでサブコレクションcart_itemsのドキュメントに追加されているarticleIdと一致する記事の詳細を表示するよう実装。
