### PR TITLE
feat(cart) : カート一覧に記事の内容を表示 #84

### DIFF
--- a/src/app/cart/cart/cart.component.html
+++ b/src/app/cart/cart/cart.component.html
@@ -1,13 +1,19 @@
-<div class="grid">
-  <mat-card *ngFor="let user of users$ | async">
-    <p>追加した記事ID : {{ user.articleId }}</p>
-    <button
-      mat-button
-      mat-raised-button
-      color="primary"
-      (click)="deleteCartItem(this.user.articleId)"
-    >
-      Delete
-    </button>
-  </mat-card>
+<div class="container">
+  <div class="grid">
+    <mat-card *ngFor="let article of articles$ | async">
+      <div class="flex">
+        <p>supplier : {{ article.supplier }}</p>
+        <p>name : {{ article.name }}</p>
+        <p>composition : {{ article.composition }}</p>
+        <button
+          mat-button
+          mat-raised-button
+          color="primary"
+          (click)="deleteCartItem(this.article.articleId)"
+        >
+          Delete
+        </button>
+      </div>
+    </mat-card>
+  </div>
 </div>

--- a/src/app/cart/cart/cart.component.scss
+++ b/src/app/cart/cart/cart.component.scss
@@ -1,0 +1,6 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 24px;
+  padding: 24px;
+}

--- a/src/app/cart/cart/cart.component.ts
+++ b/src/app/cart/cart/cart.component.ts
@@ -5,6 +5,7 @@ import { User } from '../../interfaces/user';
 import { CartService } from 'src/app/services/cart.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Article } from 'src/app/interfaces/article';
 
 @Component({
   selector: 'app-cart',
@@ -12,7 +13,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
   styleUrls: ['./cart.component.scss'],
 })
 export class CartComponent implements OnInit {
-  users$: Observable<User[]> = this.cartService.getCartItems(
+  articles$: Observable<Article[]> = this.cartService.getCartItems(
     this.authService.uid
   );
 

--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -2,23 +2,33 @@ import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { Observable, combineLatest } from 'rxjs';
 import { User } from '../interfaces/user';
+import { switchMap } from 'rxjs/operators';
+import { Article } from '../interfaces/article';
 
 @Injectable({
   providedIn: 'root',
 })
 export class CartService {
   constructor(private db: AngularFirestore) {}
-
   addCart(userId: string, articleId: string): Promise<void> {
     return this.db
       .doc(`users/${userId}/cart_items/${articleId}`)
       .set({ articleId });
   }
 
-  getCartItems(userId: string): Observable<User[]> {
+  getCartItems(userId: string): Observable<Article[]> {
     return this.db
       .collection<User>(`users/${userId}/cart_items`)
-      .valueChanges();
+      .valueChanges()
+      .pipe(
+        switchMap((items) => {
+          return combineLatest(
+            items.map((item) =>
+              this.db.doc<Article>(`articles/${item.articleId}`).valueChanges()
+            )
+          );
+        })
+      );
   }
 
   deleteCartItem(userId: string, articleId: string): Promise<void> {


### PR DESCRIPTION
fix #84 

## 実装内容
- [x] カート画面でpipeでサブコレクションcart_itemsのドキュメントに追加されているarticleIdと一致する記事の詳細を表示するよう実装。

上記内容を実装いたしました。レビューよろしくお願いいたします。

## Image
[![Image from Gyazo](https://i.gyazo.com/2372d8ad4155c990e63a670961ce9045.gif)](https://gyazo.com/2372d8ad4155c990e63a670961ce9045)
